### PR TITLE
Merge fields instead of overwriting whole doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
 node_modules/
-/types/
-/firestore/
-/firebase/
-/next/
-/web/
-/helper.d.ts
-/*.js
-/*.ts

--- a/firebase/helper.d.ts
+++ b/firebase/helper.d.ts
@@ -1,0 +1,2 @@
+export declare function to<T = Record<string, unknown>>(object: Record<string, any>): T;
+export declare function from<T = Record<string, unknown>>(object: Record<string, any>): T;

--- a/firebase/helper.js
+++ b/firebase/helper.js
@@ -1,0 +1,31 @@
+"use strict";
+exports.__esModule = true;
+exports.from = exports.to = void 0;
+function to(object) {
+    var newObject = {};
+    for (var key in object) {
+        var value = object[key];
+        if (key === "expires") {
+            newObject.expires = value.getTime();
+        }
+        else {
+            newObject[key] = value;
+        }
+    }
+    return newObject;
+}
+exports.to = to;
+function from(object) {
+    var newObject = {};
+    for (var key in object) {
+        var value = object[key];
+        if (key === "expires") {
+            newObject.expires = new Date(value);
+        }
+        else {
+            newObject[key] = value;
+        }
+    }
+    return newObject;
+}
+exports.from = from;

--- a/firebase/index.d.ts
+++ b/firebase/index.d.ts
@@ -1,0 +1,4 @@
+import { Database } from "firebase-admin/database";
+import { Adapter } from "next-auth/adapters";
+import { FirebaseAdapterProps } from "../types";
+export default function FirebaseAdapter(db: Database, options?: FirebaseAdapterProps): Adapter;

--- a/firebase/index.js
+++ b/firebase/index.js
@@ -1,0 +1,370 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+exports.__esModule = true;
+var helper_1 = require("./helper");
+function FirebaseAdapter(db, options) {
+    var _a;
+    if (options === void 0) { options = {}; }
+    var adapterCollectionName = (_a = options.adapterCollectionName) !== null && _a !== void 0 ? _a : '_next_auth_firebase_adapter_';
+    var userCollectionRef = db.ref("".concat(adapterCollectionName, "/user"));
+    var accountCollectionRef = db.ref("".concat(adapterCollectionName, "/account"));
+    var sessionCollectionRef = db.ref("".concat(adapterCollectionName, "/session"));
+    var verificationTokenCollectionRef = db.ref("".concat(adapterCollectionName, "/verificationToken"));
+    var customTokenCollectionRef = db.ref("".concat(adapterCollectionName, "/customToken"));
+    var findUserDoc = function (key) { return db.ref("".concat(adapterCollectionName, "/user/").concat(key)); };
+    var findAccountDoc = function (key) { return db.ref("".concat(adapterCollectionName, "/account/").concat(key)); };
+    var findSessionDoc = function (key) { return db.ref("".concat(adapterCollectionName, "/session/").concat(key)); };
+    var findVerificationTokenDoc = function (key) { return db.ref("".concat(adapterCollectionName, "/verificationToken/").concat(key)); };
+    var findCustomTokenDoc = function (sessionToken) { return db.ref("".concat(adapterCollectionName, "/customToken/").concat(sessionToken)); };
+    return {
+        createUser: function (data) {
+            var _a, _b, _c, _d;
+            return __awaiter(this, void 0, void 0, function () {
+                var userData, userRef, user;
+                return __generator(this, function (_e) {
+                    switch (_e.label) {
+                        case 0:
+                            userData = {
+                                name: (_a = data.name) !== null && _a !== void 0 ? _a : null,
+                                email: (_b = data.email) !== null && _b !== void 0 ? _b : null,
+                                image: (_c = data.image) !== null && _c !== void 0 ? _c : null,
+                                emailVerified: (_d = data.emailVerified) !== null && _d !== void 0 ? _d : null
+                            };
+                            return [4 /*yield*/, userCollectionRef.push(userData)];
+                        case 1:
+                            userRef = _e.sent();
+                            user = __assign({ id: userRef.key }, userData);
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUser: function (id) {
+            return __awaiter(this, void 0, void 0, function () {
+                var userSnap, user;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, findUserDoc(id).get()];
+                        case 1:
+                            userSnap = _a.sent();
+                            if (!userSnap.exists())
+                                return [2 /*return*/, null];
+                            user = userSnap.val();
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUserByEmail: function (email) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, userSnap, _a, userKey, userData, user;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            q = userCollectionRef.limitToFirst(1).orderByChild('email').equalTo(email);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            userSnap = _b.sent();
+                            if (!userSnap.exists())
+                                return [2 /*return*/, null];
+                            _a = Object.entries(userSnap.val())[0], userKey = _a[0], userData = _a[1];
+                            user = __assign({ id: userKey }, userData);
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUserByAccount: function (_a) {
+            var provider = _a.provider, providerAccountId = _a.providerAccountId;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, accountSnaps, _b, accountKey, accountData, account, userSnap, userData, user;
+                return __generator(this, function (_c) {
+                    switch (_c.label) {
+                        case 0:
+                            q = accountCollectionRef.orderByChild('providerAccountId').equalTo(providerAccountId);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            accountSnaps = _c.sent();
+                            if (!accountSnaps.exists())
+                                return [2 /*return*/, null];
+                            _b = Object.entries(accountSnaps.val()).find(function (_a) {
+                                var key = _a[0], data = _a[1];
+                                return data.provider === provider;
+                            }), accountKey = _b[0], accountData = _b[1];
+                            account = __assign({ id: accountKey }, accountData);
+                            return [4 /*yield*/, findUserDoc(account.userId).get()];
+                        case 2:
+                            userSnap = _c.sent();
+                            if (!userSnap.exists())
+                                return [2 /*return*/, null];
+                            userData = userSnap.val();
+                            user = __assign({ id: userSnap.key }, userData);
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        updateUser: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var id, userData, user;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            id = data.id, userData = __rest(data, ["id"]);
+                            return [4 /*yield*/, findUserDoc(id).set(userData)];
+                        case 1:
+                            _a.sent();
+                            user = data;
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        deleteUser: function (id) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, findUserDoc(id).remove()];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        linkAccount: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var accountData, accountRef, account;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            accountData = data;
+                            return [4 /*yield*/, accountCollectionRef.push(accountData)];
+                        case 1:
+                            accountRef = _a.sent();
+                            account = __assign({ id: accountRef.key }, accountData);
+                            return [2 /*return*/, account];
+                    }
+                });
+            });
+        },
+        unlinkAccount: function (_a) {
+            var provider = _a.provider, providerAccountId = _a.providerAccountId;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, accountSnaps, _b, accountKey, accountData;
+                return __generator(this, function (_c) {
+                    switch (_c.label) {
+                        case 0:
+                            q = accountCollectionRef.orderByChild('providerAccountId').equalTo(providerAccountId);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            accountSnaps = _c.sent();
+                            if (!accountSnaps.exists())
+                                return [2 /*return*/];
+                            _b = Object.entries(accountSnaps.val()).find(function (_a) {
+                                var key = _a[0], data = _a[1];
+                                return data.provider === provider;
+                            }), accountKey = _b[0], accountData = _b[1];
+                            return [4 /*yield*/, findAccountDoc(accountKey).remove()];
+                        case 2:
+                            _c.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        getSessionAndUser: function (sessionToken) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, sessionSnap, _a, sessionKey, sessionData, userSnap, userData, user, session;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            q = sessionCollectionRef.limitToFirst(1).orderByChild('sessionToken').equalTo(sessionToken);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            sessionSnap = _b.sent();
+                            if (!sessionSnap.exists())
+                                return [2 /*return*/, null];
+                            _a = Object.entries(sessionSnap.val())[0], sessionKey = _a[0], sessionData = _a[1];
+                            return [4 /*yield*/, findUserDoc(sessionData.userId).get()];
+                        case 2:
+                            userSnap = _b.sent();
+                            if (!userSnap.exists())
+                                return [2 /*return*/, null];
+                            userData = userSnap.val();
+                            user = __assign({ id: userSnap.key }, userData);
+                            session = __assign({ id: sessionKey }, sessionData);
+                            return [2 /*return*/, {
+                                    user: user,
+                                    session: (0, helper_1.from)(session)
+                                }];
+                    }
+                });
+            });
+        },
+        createSession: function (data) {
+            var _a, _b, _c;
+            return __awaiter(this, void 0, void 0, function () {
+                var sessionData, sessionRef, session;
+                return __generator(this, function (_d) {
+                    switch (_d.label) {
+                        case 0:
+                            sessionData = {
+                                sessionToken: (_a = data.sessionToken) !== null && _a !== void 0 ? _a : null,
+                                userId: (_b = data.userId) !== null && _b !== void 0 ? _b : null,
+                                expires: (_c = data.expires) !== null && _c !== void 0 ? _c : null
+                            };
+                            return [4 /*yield*/, sessionCollectionRef.push((0, helper_1.to)(sessionData))];
+                        case 1:
+                            sessionRef = _d.sent();
+                            session = __assign({ id: sessionRef.key }, sessionData);
+                            return [2 /*return*/, session];
+                    }
+                });
+            });
+        },
+        updateSession: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var sessionToken, sessionData, q, sessionSnap, sessionKey;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            sessionToken = data.sessionToken, sessionData = __rest(data, ["sessionToken"]);
+                            q = sessionCollectionRef.limitToFirst(1).orderByChild('sessionToken').equalTo(sessionToken);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            sessionSnap = _a.sent();
+                            if (!sessionSnap.exists())
+                                return [2 /*return*/, null];
+                            sessionKey = Object.entries(sessionSnap.val())[0][0];
+                            return [4 /*yield*/, findSessionDoc(sessionKey).set((0, helper_1.to)(sessionData))];
+                        case 2:
+                            _a.sent();
+                            return [2 /*return*/, data];
+                    }
+                });
+            });
+        },
+        deleteSession: function (sessionToken) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, sessionSnap, sessionKey;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            q = sessionCollectionRef.limitToFirst(1).orderByChild('sessionToken').equalTo(sessionToken);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            sessionSnap = _a.sent();
+                            if (!sessionSnap.exists())
+                                return [2 /*return*/, null];
+                            sessionKey = Object.entries(sessionSnap.val())[0][0];
+                            return [4 /*yield*/, Promise.allSettled([
+                                    findSessionDoc(sessionKey).remove(),
+                                    findCustomTokenDoc(sessionToken).remove(),
+                                ])];
+                        case 2:
+                            _a.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        createVerificationToken: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var verificationTokenRef, verificationToken;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, verificationTokenCollectionRef.push(data)];
+                        case 1:
+                            verificationTokenRef = _a.sent();
+                            verificationToken = __assign({ id: verificationTokenRef.key }, (0, helper_1.to)(data));
+                            return [2 /*return*/, verificationToken];
+                    }
+                });
+            });
+        },
+        useVerificationToken: function (_a) {
+            var identifier = _a.identifier, token = _a.token;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, verificationTokenSnap, _b, verificationTokenKey, verificationTokenData;
+                return __generator(this, function (_c) {
+                    switch (_c.label) {
+                        case 0:
+                            q = verificationTokenCollectionRef.orderByChild('token').equalTo(token);
+                            return [4 /*yield*/, q.once('value')];
+                        case 1:
+                            verificationTokenSnap = _c.sent();
+                            if (!verificationTokenSnap.exists())
+                                return [2 /*return*/, null];
+                            _b = Object.entries(verificationTokenSnap.val()).find(function (_a) {
+                                var key = _a[0], data = _a[1];
+                                return data.identifier === identifier;
+                            }), verificationTokenKey = _b[0], verificationTokenData = _b[1];
+                            return [4 /*yield*/, findVerificationTokenDoc(verificationTokenKey).remove()];
+                        case 2:
+                            _c.sent();
+                            return [2 /*return*/, (0, helper_1.from)(verificationTokenData)];
+                    }
+                });
+            });
+        }
+    };
+}
+exports["default"] = FirebaseAdapter;

--- a/firestore/helper.d.ts
+++ b/firestore/helper.d.ts
@@ -1,0 +1,5 @@
+import { DocumentData, Query, QueryDocumentSnapshot } from "firebase-admin/firestore";
+export declare function findOne(q: Query<DocumentData>): Promise<QueryDocumentSnapshot<DocumentData> | null>;
+export declare function findMany(q: Query<DocumentData>): Promise<QueryDocumentSnapshot<DocumentData>[]>;
+export declare function from<T = Record<string, unknown>>(object: Record<string, any>): T;
+export declare function asyncMap<T>(promiseFns: (() => Promise<T>)[], max: number): Promise<unknown>;

--- a/firestore/helper.js
+++ b/firestore/helper.js
@@ -1,0 +1,112 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+exports.__esModule = true;
+exports.asyncMap = exports.from = exports.findMany = exports.findOne = void 0;
+function findOne(q) {
+    return __awaiter(this, void 0, void 0, function () {
+        var querySnap, result;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, q.get()];
+                case 1:
+                    querySnap = _a.sent();
+                    result = null;
+                    querySnap.forEach(function (doc) { return result = doc; });
+                    return [2 /*return*/, result];
+            }
+        });
+    });
+}
+exports.findOne = findOne;
+function findMany(q) {
+    return __awaiter(this, void 0, void 0, function () {
+        var querySnap, docs;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, q.get()];
+                case 1:
+                    querySnap = _a.sent();
+                    docs = [];
+                    querySnap.forEach(function (doc) { return docs.push(doc); });
+                    return [2 /*return*/, docs];
+            }
+        });
+    });
+}
+exports.findMany = findMany;
+function from(object) {
+    var newObject = {};
+    for (var key in object) {
+        var value = object[key];
+        if (key === "expires") {
+            newObject.expires = value.toDate();
+        }
+        else {
+            newObject[key] = value;
+        }
+    }
+    return newObject;
+}
+exports.from = from;
+function asyncMap(promiseFns, max) {
+    var result = [];
+    var count = 0;
+    var cursor = 0;
+    return new Promise(function (res) {
+        function run() {
+            var _loop_1 = function () {
+                count++;
+                var index = cursor++;
+                promiseFns[index]()
+                    .then(function (value) {
+                    result[index] = value;
+                }, function (rej) { return console.log(rej); })["catch"](function (err) { return console.error(err); })["finally"](function () {
+                    run();
+                    count--;
+                    if (!count)
+                        res(result);
+                });
+            };
+            while (count < max && cursor < promiseFns.length) {
+                _loop_1();
+            }
+        }
+        run();
+    });
+}
+exports.asyncMap = asyncMap;

--- a/firestore/index.d.ts
+++ b/firestore/index.d.ts
@@ -1,0 +1,4 @@
+import { Firestore } from "firebase-admin/firestore";
+import { Adapter } from "next-auth/adapters";
+import { FirebaseAdapterProps } from "../types";
+export default function FirestoreAdapter(db: Firestore, options?: FirebaseAdapterProps): Adapter;

--- a/firestore/index.js
+++ b/firestore/index.js
@@ -169,7 +169,7 @@ function FirestoreAdapter(db, options) {
                             return [4 /*yield*/, findUserDoc(id).get()];
                         case 2:
                             userSnap = _a.sent();
-                            user = userSnap.data();
+                            user = __assign({ id: userSnap.id }, userSnap.data());
                             return [2 /*return*/, user];
                     }
                 });

--- a/firestore/index.js
+++ b/firestore/index.js
@@ -1,0 +1,359 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+exports.__esModule = true;
+var helper_1 = require("./helper");
+function FirestoreAdapter(db, options) {
+    var _a;
+    if (options === void 0) { options = {}; }
+    var adapterCollectionName = (_a = options.adapterCollectionName) !== null && _a !== void 0 ? _a : '_next_auth_firebase_adapter_';
+    var userCollectionRef = db.collection(adapterCollectionName).doc('store').collection('user');
+    var accountCollectionRef = db.collection(adapterCollectionName).doc('store').collection('account');
+    var sessionCollectionRef = db.collection(adapterCollectionName).doc('store').collection('session');
+    var verificationTokenCollectionRef = db.collection(adapterCollectionName).doc('store').collection('verificationToken');
+    var customTokenCollectionRef = db.collection(adapterCollectionName).doc('store').collection('customToken');
+    var findUserDoc = function (id) { return userCollectionRef.doc(id); };
+    var findAccountDoc = function (id) { return accountCollectionRef.doc(id); };
+    var findSessionDoc = function (id) { return sessionCollectionRef.doc(id); };
+    var findVerificationTokenDoc = function (id) { return verificationTokenCollectionRef.doc(id); };
+    var findCustomTokenDoc = function (sessionToken) { return customTokenCollectionRef.doc(sessionToken); };
+    return {
+        createUser: function (data) {
+            var _a, _b, _c, _d;
+            return __awaiter(this, void 0, void 0, function () {
+                var userData, userRef, user;
+                return __generator(this, function (_e) {
+                    switch (_e.label) {
+                        case 0:
+                            userData = {
+                                name: (_a = data.name) !== null && _a !== void 0 ? _a : null,
+                                email: (_b = data.email) !== null && _b !== void 0 ? _b : null,
+                                image: (_c = data.image) !== null && _c !== void 0 ? _c : null,
+                                emailVerified: (_d = data.emailVerified) !== null && _d !== void 0 ? _d : null
+                            };
+                            return [4 /*yield*/, userCollectionRef.add(userData)];
+                        case 1:
+                            userRef = _e.sent();
+                            user = __assign({ id: userRef.id }, userData);
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUser: function (id) {
+            return __awaiter(this, void 0, void 0, function () {
+                var userSnap, user;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, findUserDoc(id).get()];
+                        case 1:
+                            userSnap = _a.sent();
+                            if (!userSnap.exists)
+                                return [2 /*return*/, null];
+                            user = userSnap.data();
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUserByEmail: function (email) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, userRef, user;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            q = userCollectionRef.where('email', '==', email).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            userRef = _a.sent();
+                            if (!userRef)
+                                return [2 /*return*/, null];
+                            user = __assign({ id: userRef.id }, userRef.data());
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        getUserByAccount: function (_a) {
+            var provider = _a.provider, providerAccountId = _a.providerAccountId;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, accountRef, account, userRef, userData, user;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            q = accountCollectionRef.where('provider', '==', provider).where('providerAccountId', '==', providerAccountId).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            accountRef = _b.sent();
+                            if (!accountRef)
+                                return [2 /*return*/, null];
+                            account = __assign({ id: accountRef.id }, accountRef.data());
+                            return [4 /*yield*/, findUserDoc(account.userId).get()];
+                        case 2:
+                            userRef = _b.sent();
+                            if (!userRef.exists)
+                                return [2 /*return*/, null];
+                            userData = userRef.data();
+                            user = __assign({ id: userRef.id }, userData);
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        updateUser: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var id, userData, userSnap, user;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            id = data.id, userData = __rest(data, ["id"]);
+                            return [4 /*yield*/, findUserDoc(id).set(userData, { merge: true })];
+                        case 1:
+                            _a.sent();
+                            return [4 /*yield*/, findUserDoc(id).get()];
+                        case 2:
+                            userSnap = _a.sent();
+                            user = userSnap.data();
+                            return [2 /*return*/, user];
+                    }
+                });
+            });
+        },
+        deleteUser: function (id) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, findUserDoc(id)["delete"]()];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        linkAccount: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var accountData, accountRef, account;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            accountData = data;
+                            return [4 /*yield*/, accountCollectionRef.add(accountData)];
+                        case 1:
+                            accountRef = _a.sent();
+                            account = __assign({ id: accountRef.id }, accountData);
+                            return [2 /*return*/, account];
+                    }
+                });
+            });
+        },
+        unlinkAccount: function (_a) {
+            var provider = _a.provider, providerAccountId = _a.providerAccountId;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, accountRef;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            q = accountCollectionRef.where('provider', '==', provider).where('providerAccountId', '==', providerAccountId).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            accountRef = _b.sent();
+                            if (!accountRef)
+                                return [2 /*return*/];
+                            return [4 /*yield*/, findAccountDoc(accountRef.id)["delete"]()];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        getSessionAndUser: function (sessionToken) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, sessionRef, sessionData, userRef, userData, user, session;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            q = sessionCollectionRef.where('sessionToken', '==', sessionToken).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            sessionRef = _a.sent();
+                            if (!sessionRef)
+                                return [2 /*return*/, null];
+                            sessionData = sessionRef.data();
+                            return [4 /*yield*/, findUserDoc(sessionData.userId).get()];
+                        case 2:
+                            userRef = _a.sent();
+                            if (!userRef.exists)
+                                return [2 /*return*/, null];
+                            userData = userRef.data();
+                            user = __assign({ id: userRef.id }, userData);
+                            session = __assign({ id: sessionRef.id }, sessionData);
+                            return [2 /*return*/, {
+                                    user: user,
+                                    session: (0, helper_1.from)(session)
+                                }];
+                    }
+                });
+            });
+        },
+        createSession: function (data) {
+            var _a, _b, _c;
+            return __awaiter(this, void 0, void 0, function () {
+                var sessionData, sessionRef, session;
+                return __generator(this, function (_d) {
+                    switch (_d.label) {
+                        case 0:
+                            sessionData = {
+                                sessionToken: (_a = data.sessionToken) !== null && _a !== void 0 ? _a : null,
+                                userId: (_b = data.userId) !== null && _b !== void 0 ? _b : null,
+                                expires: (_c = data.expires) !== null && _c !== void 0 ? _c : null
+                            };
+                            return [4 /*yield*/, sessionCollectionRef.add(sessionData)];
+                        case 1:
+                            sessionRef = _d.sent();
+                            session = __assign({ id: sessionRef.id }, sessionData);
+                            return [2 /*return*/, session];
+                    }
+                });
+            });
+        },
+        updateSession: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var sessionToken, sessionData, q, sessionRef;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            sessionToken = data.sessionToken, sessionData = __rest(data, ["sessionToken"]);
+                            q = sessionCollectionRef.where('sessionToken', '==', sessionToken).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            sessionRef = _a.sent();
+                            if (!sessionRef)
+                                return [2 /*return*/];
+                            return [4 /*yield*/, findSessionDoc(sessionRef.id).set(sessionData)];
+                        case 2:
+                            _a.sent();
+                            return [2 /*return*/, data];
+                    }
+                });
+            });
+        },
+        deleteSession: function (sessionToken) {
+            return __awaiter(this, void 0, void 0, function () {
+                var q, sessionRef;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            q = sessionCollectionRef.where('sessionToken', '==', sessionToken).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            sessionRef = _a.sent();
+                            if (!sessionRef)
+                                return [2 /*return*/];
+                            return [4 /*yield*/, Promise.allSettled([
+                                    findSessionDoc(sessionRef.id)["delete"](),
+                                    findCustomTokenDoc(sessionToken)["delete"](),
+                                ])];
+                        case 2:
+                            _a.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        },
+        createVerificationToken: function (data) {
+            return __awaiter(this, void 0, void 0, function () {
+                var verificationTokenRef, verificationToken;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, verificationTokenCollectionRef.add(data)];
+                        case 1:
+                            verificationTokenRef = _a.sent();
+                            verificationToken = __assign({ id: verificationTokenRef.id }, data);
+                            return [2 /*return*/, verificationToken];
+                    }
+                });
+            });
+        },
+        useVerificationToken: function (_a) {
+            var identifier = _a.identifier, token = _a.token;
+            return __awaiter(this, void 0, void 0, function () {
+                var q, verificationTokenRef, verificationToken;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0:
+                            q = verificationTokenCollectionRef.where('identifier', '==', identifier).where('token', '==', token).limit(1);
+                            return [4 /*yield*/, (0, helper_1.findOne)(q)];
+                        case 1:
+                            verificationTokenRef = _b.sent();
+                            if (!verificationTokenRef)
+                                return [2 /*return*/, null];
+                            verificationToken = verificationTokenRef.data();
+                            return [4 /*yield*/, findVerificationTokenDoc(verificationTokenRef.id)["delete"]()];
+                        case 2:
+                            _b.sent();
+                            return [2 /*return*/, (0, helper_1.from)(verificationToken)];
+                    }
+                });
+            });
+        }
+    };
+}
+exports["default"] = FirestoreAdapter;

--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,0 +1,2 @@
+export declare function asyncMap<T>(promiseFns: (() => Promise<T>)[], max: number): Promise<unknown>;
+export declare function sleep(ms: number): Promise<void>;

--- a/helper.js
+++ b/helper.js
@@ -1,0 +1,34 @@
+"use strict";
+exports.__esModule = true;
+exports.sleep = exports.asyncMap = void 0;
+function asyncMap(promiseFns, max) {
+    var result = [];
+    var count = 0;
+    var cursor = 0;
+    return new Promise(function (res) {
+        function run() {
+            var _loop_1 = function () {
+                count++;
+                var index = cursor++;
+                promiseFns[index]()
+                    .then(function (value) {
+                    result[index] = value;
+                }, function (rej) { return console.log(rej); })["catch"](function (err) { return console.error(err); })["finally"](function () {
+                    run();
+                    count--;
+                    if (!count)
+                        res(result);
+                });
+            };
+            while (count < max && cursor < promiseFns.length) {
+                _loop_1();
+            }
+        }
+        run();
+    });
+}
+exports.asyncMap = asyncMap;
+function sleep(ms) {
+    return new Promise(function (res) { return setTimeout(res, ms); });
+}
+exports.sleep = sleep;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+export { default as FirebaseAdapter } from './firebase';
+export { default as FirestoreAdapter } from './firestore';
+export { default } from './firestore';
+export { createFirebaseCustomTokenHandler, createRemoveExpiredSessions } from './next';
+export * from './web';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,27 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+exports.__esModule = true;
+exports.createRemoveExpiredSessions = exports.createFirebaseCustomTokenHandler = exports["default"] = exports.FirestoreAdapter = exports.FirebaseAdapter = void 0;
+var firebase_1 = require("./firebase");
+__createBinding(exports, firebase_1, "default", "FirebaseAdapter");
+var firestore_1 = require("./firestore");
+__createBinding(exports, firestore_1, "default", "FirestoreAdapter");
+var firestore_2 = require("./firestore");
+__createBinding(exports, firestore_2, "default");
+var next_1 = require("./next");
+__createBinding(exports, next_1, "createFirebaseCustomTokenHandler");
+__createBinding(exports, next_1, "createRemoveExpiredSessions");
+__exportStar(require("./web"), exports);

--- a/next/index.d.ts
+++ b/next/index.d.ts
@@ -1,0 +1,18 @@
+import { Firestore } from 'firebase-admin/firestore';
+import { NextApiRequest, NextApiResponse } from "next";
+import { Session } from "next-auth";
+import { Adapter } from "next-auth/adapters";
+import { Database } from 'firebase-admin/database';
+export declare function getCustomToken(db: Firestore | Database, sessionToken: string, adapterCollectionName?: string): Promise<string | undefined>;
+export declare function updateCustomToken(db: Firestore | Database, sessionToken: string, token: string, adapterCollectionName?: string): Promise<string>;
+export declare function getSessionToken(req: NextApiRequest): string;
+export declare function createFirebaseCustomTokenHandler({ db, adapterCollectionName, method, additionalClaims, }: {
+    db: Firestore | Database;
+    adapterCollectionName?: string;
+    method?: string;
+    additionalClaims?: (session: Session) => any;
+}): (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
+export declare function createRemoveExpiredSessions({ db, adapterCollectionName, }: {
+    db: Firestore;
+    adapterCollectionName?: string;
+}): (adapter: Adapter, limit?: number, asyncMax?: number) => Promise<void>;

--- a/next/index.js
+++ b/next/index.js
@@ -1,0 +1,176 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+exports.createRemoveExpiredSessions = exports.createFirebaseCustomTokenHandler = exports.getSessionToken = exports.updateCustomToken = exports.getCustomToken = void 0;
+var firebase_admin_1 = __importDefault(require("firebase-admin"));
+var firestore_1 = require("firebase-admin/firestore");
+var react_1 = require("next-auth/react");
+var helper_1 = require("../firestore/helper");
+var helper_2 = require("../helper");
+function getCustomToken(db, sessionToken, adapterCollectionName) {
+    if (adapterCollectionName === void 0) { adapterCollectionName = '_next_auth_firebase_adapter_'; }
+    return __awaiter(this, void 0, void 0, function () {
+        var token, expires, tokenDocRef, tokenDoc, tokenSnap;
+        var _a, _b;
+        return __generator(this, function (_c) {
+            switch (_c.label) {
+                case 0:
+                    if (!(db instanceof firestore_1.Firestore)) return [3 /*break*/, 2];
+                    tokenDocRef = db.collection(adapterCollectionName).doc('store').collection('customToken').doc(sessionToken);
+                    return [4 /*yield*/, tokenDocRef.get()];
+                case 1:
+                    tokenDoc = _c.sent();
+                    if (!tokenDoc.exists)
+                        return [2 /*return*/];
+                    (_a = tokenDoc.data(), token = _a.token, expires = _a.expires);
+                    return [3 /*break*/, 4];
+                case 2: return [4 /*yield*/, db.ref("".concat(adapterCollectionName, "/customToken/").concat(sessionToken)).get()];
+                case 3:
+                    tokenSnap = _c.sent();
+                    if (!tokenSnap.exists())
+                        return [2 /*return*/];
+                    (_b = tokenSnap.val(), token = _b.token, expires = _b.expires);
+                    _c.label = 4;
+                case 4:
+                    if (Date.now() > new Date(expires).getTime())
+                        return [2 /*return*/];
+                    return [2 /*return*/, token];
+            }
+        });
+    });
+}
+exports.getCustomToken = getCustomToken;
+function updateCustomToken(db, sessionToken, token, adapterCollectionName) {
+    if (adapterCollectionName === void 0) { adapterCollectionName = '_next_auth_firebase_adapter_'; }
+    return __awaiter(this, void 0, void 0, function () {
+        var tokenData, tokenDocRef;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    tokenData = {
+                        token: token,
+                        expires: Date.now() + 60 * 60 * 1000
+                    };
+                    if (!(db instanceof firestore_1.Firestore)) return [3 /*break*/, 2];
+                    tokenDocRef = db.collection(adapterCollectionName).doc('store').collection('customToken').doc(sessionToken);
+                    return [4 /*yield*/, tokenDocRef.set(tokenData)];
+                case 1:
+                    _a.sent();
+                    return [3 /*break*/, 4];
+                case 2: return [4 /*yield*/, db.ref("".concat(adapterCollectionName, "/customToken/").concat(sessionToken)).update(tokenData)];
+                case 3:
+                    _a.sent();
+                    _a.label = 4;
+                case 4: return [2 /*return*/, token];
+            }
+        });
+    });
+}
+exports.updateCustomToken = updateCustomToken;
+function getSessionToken(req) {
+    var _a, _b;
+    return (_b = (_a = req.cookies['__Secure-next-auth.session-token']) !== null && _a !== void 0 ? _a : req.cookies['next-auth.session-token']) !== null && _b !== void 0 ? _b : '';
+}
+exports.getSessionToken = getSessionToken;
+function createFirebaseCustomTokenHandler(_a) {
+    var db = _a.db, _b = _a.adapterCollectionName, adapterCollectionName = _b === void 0 ? '_next_auth_firebase_adapter_' : _b, _c = _a.method, method = _c === void 0 ? 'GET' : _c, additionalClaims = _a.additionalClaims;
+    return function firebaseCustomTokenHandler(req, res) {
+        return __awaiter(this, void 0, void 0, function () {
+            var session, sessionToken, user, email, token;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (req.method !== method)
+                            return [2 /*return*/, res.status(403).json(false)];
+                        return [4 /*yield*/, (0, react_1.getSession)({ req: req })];
+                    case 1:
+                        session = _a.sent();
+                        if (!session)
+                            return [2 /*return*/, res.status(403).json(false)];
+                        sessionToken = getSessionToken(req);
+                        if (!sessionToken)
+                            console.warn('No sessionToken');
+                        user = session.user;
+                        email = user.email;
+                        return [4 /*yield*/, getCustomToken(db, sessionToken, adapterCollectionName)];
+                    case 2:
+                        token = _a.sent();
+                        if (token)
+                            return [2 /*return*/, res.json(token)];
+                        return [4 /*yield*/, firebase_admin_1["default"]
+                                .auth()
+                                .createCustomToken(email, Object.assign({}, additionalClaims === null || additionalClaims === void 0 ? void 0 : additionalClaims(session), { sessionToken: sessionToken, uid: btoa(email) }))];
+                    case 3:
+                        token = _a.sent();
+                        return [4 /*yield*/, updateCustomToken(db, sessionToken, token, adapterCollectionName)];
+                    case 4:
+                        _a.sent();
+                        return [2 /*return*/, res.json(token)];
+                }
+            });
+        });
+    };
+}
+exports.createFirebaseCustomTokenHandler = createFirebaseCustomTokenHandler;
+function createRemoveExpiredSessions(_a) {
+    var db = _a.db, _b = _a.adapterCollectionName, adapterCollectionName = _b === void 0 ? '_next_auth_firebase_adapter_' : _b;
+    return function removeExpiredSessions(adapter, limit, asyncMax) {
+        if (limit === void 0) { limit = 100; }
+        if (asyncMax === void 0) { asyncMax = 30; }
+        return __awaiter(this, void 0, void 0, function () {
+            var q, expiredSessionDocs;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        q = db.collection(adapterCollectionName).doc('store').collection('session').where('expires', '<', new Date()).limit(limit);
+                        return [4 /*yield*/, (0, helper_1.findMany)(q)];
+                    case 1:
+                        expiredSessionDocs = _a.sent();
+                        return [4 /*yield*/, (0, helper_2.asyncMap)(expiredSessionDocs.map(function (doc) { return function () { return adapter.deleteSession(doc.data().sessionToken); }; }), asyncMax)];
+                    case 2:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+}
+exports.createRemoveExpiredSessions = createRemoveExpiredSessions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,31 @@
 {
   "name": "@lowfront/firebase-adapter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lowfront/firebase-adapter",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
+      "devDependencies": {
+        "firebase": "^9.9.1",
+        "firebase-admin": "^11.0.0",
+        "next": "^12.2.3",
+        "next-auth": "^4.10.2"
+      },
       "peerDependencies": {
-        "firebase": "^9.8",
-        "firebase-admin": "^10.2",
-        "next": "^12.1",
-        "next-auth": "^4.3"
+        "firebase": "^9.x",
+        "firebase-admin": "^10.x",
+        "next": "^12.x",
+        "next-auth": "^4.x"
       }
     },
     "node_modules/@babel/runtime": {
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -31,7 +37,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
       "integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "text-decoding": "^1.0.0"
       },
@@ -43,7 +49,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.8.0.tgz",
       "integrity": "sha512-wkcwainNm8Cu2xkJpDSHfhBSdDJn86Q1TZNmLWc67VrhZUHXIKXxIqb65/tNUVE+I8+sFiDDNwA+9R3MqTQTaA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -59,7 +65,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.1.13.tgz",
       "integrity": "sha512-QC1DH/Dwc8fBihn0H+jocBWyE17GF1fOCpCrpAiQ2u16F/NqsVDVG4LjIqdhq963DXaXneNY7oDwa25Up682AA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-types": "0.7.0",
@@ -75,13 +81,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.7.0.tgz",
       "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/app": {
       "version": "0.7.29",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.29.tgz",
       "integrity": "sha512-jT47plTi/O0lpXEXPx5t/dH/3BVnP9Tq/D8SZkhMUXPYlYDudvepIiV3VOW8XxbbHU/X+JyY0qG5CoWxIk0teg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -94,7 +100,7 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.12.tgz",
       "integrity": "sha512-l+MmvupSGT/F+I5ei7XjhEfpoL4hLVJr0vUwcG5NEf2hAkQnySli9fnbl9fZu1BJaQ2kthrMmtg1gcbcM9BUCQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -109,7 +115,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.12.tgz",
       "integrity": "sha512-GFppNLlUyMN9Iq31ME/+GkjRVKlc+MeanzUKQ9UaR73ZsYH3oX3Ja+xjoYgixaVJDDG+ofBYR7ZXTkkQdSR/pw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/app-check": "0.5.12",
         "@firebase/app-check-types": "0.4.0",
@@ -126,19 +132,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
       "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/app-check-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.4.0.tgz",
       "integrity": "sha512-SsWafqMABIOu7zLgWbmwvHGOeQQVQlwm42kwwubsmfLmL4Sf5uGpBfDhQ0CAkpi7bkJ/NwNFKafNDL9prRNP0Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/app-compat": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.30.tgz",
       "integrity": "sha512-t51oJEJzjts4D5C7Nol0Ua7dqhpQSlcWSa7X1VtL+zjcTZ92ibYmwQjXomexBmlKvCUamGClMAEBfEgUtr0Wug==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/app": "0.7.29",
         "@firebase/component": "0.5.17",
@@ -151,13 +157,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
       "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/auth": {
       "version": "0.20.5",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.20.5.tgz",
       "integrity": "sha512-SbKj7PCAuL0lXEToUOoprc1im2Lr/bzOePXyPC7WWqVgdVBt0qovbfejlzKYwJLHUAPg9UW1y3XYe3IlbXr77w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -174,7 +180,7 @@
       "version": "0.2.18",
       "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.2.18.tgz",
       "integrity": "sha512-Fw2PJS0G/tGrfyEBcYJQ42sfy5+sANrK5xd7tuzgV7zLFW5rYkHUIZngXjuOBwLOcfO2ixa/FavfeJle3oJ38Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/auth": "0.20.5",
         "@firebase/auth-types": "0.11.0",
@@ -192,7 +198,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
       "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -202,7 +208,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
       "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -212,7 +218,7 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
       "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
@@ -222,7 +228,7 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.3.tgz",
       "integrity": "sha512-ZE+QJqQUaCTZiIzGq3RJLo64HRMtbdaEwyDhfZyPEzMJV4kyLsw3cHdEHVCtBmdasTvwtpO2YRFmd4AXAoKtNw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/auth-interop-types": "0.1.6",
         "@firebase/component": "0.5.17",
@@ -236,7 +242,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.3.tgz",
       "integrity": "sha512-uwSMnbjlSQM5gQRq8OoBLs7uc7obwsl0D6kSDAnMOlPtPl9ert79Rq9faU/COjybsJ8l7tNXMVYYJo3mQ5XNrA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/database": "0.13.3",
@@ -250,7 +256,7 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.11.tgz",
       "integrity": "sha512-27V3eFomWCZqLR6qb3Q9eS2lsUtulhSHeDNaL6fImwnhvMYTmf6ZwMfRWupgi8AFwW4s91g9Oc1/fkQtJGHKQw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/app-types": "0.7.0",
         "@firebase/util": "1.6.3"
@@ -260,7 +266,7 @@
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.13.tgz",
       "integrity": "sha512-wLsbWflFoWDg9NprulzTAjtapLA3dfaG1Dsa9OUsgPRDGg5jfeo60n43d94fesX4crE+C5vkFhLQKMgsEGpr9w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -282,7 +288,7 @@
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.22.tgz",
       "integrity": "sha512-1HWmJtbxhDzAV7984XSQX7tp0MzjhRFnBygpU6k6H2m0Ey9JVDTPK8lIlZCctjCCA2cBsek7yAD+rDnpWC+KRw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/firestore": "3.4.13",
@@ -298,7 +304,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
       "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -308,7 +314,7 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.8.4.tgz",
       "integrity": "sha512-o1bB0xMyQKe+b246zGnjwHj4R6BH4mU2ZrSaa/3QvTpahUQ3hqYfkZPLOXCU7+vEFxHb3Hd4UUjkFhxoAcPqLA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/app-check-interop-types": "0.1.0",
         "@firebase/auth-interop-types": "0.1.6",
@@ -326,7 +332,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.2.4.tgz",
       "integrity": "sha512-Crfn6il1yXGuXkjSd8nKrqR4XxPvuP19g64bXpM6Ix67qOkQg676kyOuww0FF17xN0NSXHfG8Pyf+CUrx8wJ5g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/functions": "0.8.4",
@@ -342,13 +348,13 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.0.tgz",
       "integrity": "sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/installations": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.5.12.tgz",
       "integrity": "sha512-Zq43fCE0PB5tGJ3ojzx5RNQzKdej1188qgAk22rwjuhP7npaG/PlJqDG1/V0ZjTLRePZ1xGrfXSPlA17c/vtNw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/util": "1.6.3",
@@ -363,7 +369,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.1.12.tgz",
       "integrity": "sha512-BIhFpWIn/GkuOa+jnXkp3SDJT2RLYJF6MWpinHIBKFJs7MfrgYZ3zQ1AlhobDEql+bkD1dK4dB5sNcET2T+EyA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -379,7 +385,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.4.0.tgz",
       "integrity": "sha512-nXxWKQDvBGctuvsizbUEJKfxXU9WAaDhon+j0jpjIfOJkvkj3YHqlLB/HeYjpUn85Pb22BjplpTnDn4Gm9pc3A==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x"
       }
@@ -388,7 +394,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
       "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -397,7 +403,7 @@
       "version": "0.9.16",
       "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.9.16.tgz",
       "integrity": "sha512-Yl9gGrAvJF6C1gg3+Cr2HxlL6APsDEkrorkFafmSP1l+rg1epZKoOAcKJbSF02Vtb50wfb9FqGGy8tzodgETxg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -414,7 +420,7 @@
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.1.16.tgz",
       "integrity": "sha512-uG7rWcXJzU8vvlEBFpwG1ndw/GURrrmKcwsHopEWbsPGjMRaVWa7XrdKbvIR7IZohqPzcC/V9L8EeqF4Q4lz8w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/messaging": "0.9.16",
@@ -429,13 +435,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz",
       "integrity": "sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/performance": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.5.12.tgz",
       "integrity": "sha512-MPVTkOkGrm2SMQgI1FPNBm85y2pPqlPb6VDjIMCWkVpAr6G1IZzUT24yEMySRcIlK/Hh7/Qu1Nu5ASRzRuX6+Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -451,7 +457,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.1.12.tgz",
       "integrity": "sha512-IBORzUeGY1MGdZnsix9Mu5z4+C3WHIwalu0usxvygL0EZKHztGG8bppYPGH/b5vvg8QyHs9U+Pn1Ot2jZhffQQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -468,13 +474,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.1.0.tgz",
       "integrity": "sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/polyfill": {
       "version": "0.3.36",
       "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
       "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "core-js": "3.6.5",
         "promise-polyfill": "8.1.3",
@@ -485,7 +491,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.3.11.tgz",
       "integrity": "sha512-qA84dstrvVpO7rWT/sb2CLv1kjHVmz59SRFPKohJJYFBcPOGK4Pe4FWWhKAE9yg1Gnl0qYAGkahOwNawq3vE0g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -501,7 +507,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.1.12.tgz",
       "integrity": "sha512-Yz7Gtb2rLa7ykXZX9DnSTId8CXd++jFFLW3foUImrYwJEtWgLJc7gwkRfd1M73IlKGNuQAY+DpUNF0n1dLbecA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -518,13 +524,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz",
       "integrity": "sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@firebase/storage": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.9.9.tgz",
       "integrity": "sha512-Zch7srLT2SIh9y2nCVv/4Kne0HULn7OPkmreY70BJTUJ+g5WLRjggBq6x9fV5ls9V38iqMWfn4prxzX8yIc08A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/util": "1.6.3",
@@ -539,7 +545,7 @@
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.1.17.tgz",
       "integrity": "sha512-nOYmnpI0gwoz5nROseMi9WbmHGf+xumfsOvdPyMZAjy0VqbDnpKIwmTUZQBdR+bLuB5oIkHQsvw9nbb1SH+PzQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/storage": "0.9.9",
@@ -555,7 +561,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
       "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "@firebase/app-types": "0.x",
         "@firebase/util": "1.x"
@@ -565,7 +571,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
       "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -574,14 +580,14 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.6.2.tgz",
       "integrity": "sha512-zThUKcqIU6utWzM93uEvhlh8qj8A5LMPFJPvk/ODb+8GSSif19xM2Lw1M2ijyBy8+6skSkQBbavPzOU5Oh/8tQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.15.1.tgz",
-      "integrity": "sha512-2PWsCkEF1W02QbghSeRsNdYKN1qavrHBP3m72gPDMHQSYrGULOaTi7fSJquQmAtc4iPVB2/x6h80rdLHTATQtA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+      "integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
@@ -596,8 +602,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
       "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -607,65 +613,60 @@
       }
     },
     "node_modules/@google-cloud/projectify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
-      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@google-cloud/promisify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
-      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+      "integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "5.20.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
-      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.4.2.tgz",
+      "integrity": "sha512-rnwx++XIxy63t1CREGlY2+H+tvuvYmkiIqJdq0IRzGaah9bDetV+qJVl5Mvi5aPhgoqn3UNnKGv9SPcETimFgw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@google-cloud/paginator": "^3.0.7",
-        "@google-cloud/projectify": "^2.0.0",
-        "@google-cloud/promisify": "^2.0.0",
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
         "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
-        "configstore": "^5.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.14.1",
-        "hash-stream-validation": "^0.2.2",
+        "gaxios": "^5.0.0",
+        "google-auth-library": "^8.0.1",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
-        "pumpify": "^2.0.0",
-        "retry-request": "^4.2.2",
-        "stream-events": "^1.0.4",
-        "teeny-request": "^7.1.3",
-        "uuid": "^8.0.0",
-        "xdg-basedir": "^4.0.0"
+        "retry-request": "^5.0.0",
+        "teeny-request": "^8.0.0",
+        "uuid": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.8.tgz",
       "integrity": "sha512-Nt5tufF/O5Q310kP0cDzxznWMZW58GCTZhUUiAQ9B0K0ANKNQ4Lj/K9XK0vZg+UBKq5/7z7+8mXHHfrcwoeFJQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -678,7 +679,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
       "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -697,8 +698,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
       "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+      "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -722,13 +723,13 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
       "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.6.13",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
       "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -747,7 +748,7 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
       "integrity": "sha512-2lWKP5Xcvnor70NaaROZXBvU8z9mFReePCG8NhZw6NyNGnPvC+8s+Cre/63LAB1LKzWw/e9bZJnQUg0gYFRb2Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "12.2.3",
@@ -756,11 +757,11 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -772,11 +773,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -788,11 +789,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -804,11 +805,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -820,11 +821,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -836,11 +837,11 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -852,11 +853,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -868,11 +869,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -884,11 +885,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -900,11 +901,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -916,11 +917,11 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -932,11 +933,11 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -948,11 +949,11 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -961,7 +962,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -970,7 +971,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.2.tgz",
       "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -979,31 +980,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1013,37 +1014,37 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
       "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1052,8 +1053,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1062,7 +1063,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1072,7 +1073,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1081,7 +1082,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -1093,7 +1094,7 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1104,37 +1105,37 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "17.0.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
       "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -1144,8 +1145,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -1157,8 +1158,8 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1170,7 +1171,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1179,7 +1180,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1194,8 +1195,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1204,8 +1205,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -1214,12 +1215,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1234,15 +1236,14 @@
           "url": "https://feross.org/support"
         }
       ],
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1251,7 +1252,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1261,12 +1262,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "peer": true
+      "dev": true
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001339",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
       "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1276,14 +1278,13 @@
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1294,7 +1295,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1306,14 +1307,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -1325,31 +1326,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "peer": true
-    },
-    "node_modules/configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1358,8 +1341,8 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -1369,23 +1352,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "peer": true
-    },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1398,25 +1371,12 @@
         }
       }
     },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/duplexify": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
       "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -1428,7 +1388,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -1437,14 +1397,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "peer": true
+      "dev": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1453,14 +1413,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1469,8 +1429,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1479,28 +1439,28 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/fast-text-encoding": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
-      "integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
-      "optional": true,
-      "peer": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
       "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "websocket-driver": ">=0.5.1"
       },
@@ -1512,7 +1472,7 @@
       "version": "9.9.1",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.1.tgz",
       "integrity": "sha512-1saLd91mmfNWOdP3DpkCAyXcrwB0iJXZoYY8S98ljp1erL+eUPHu+AHw8ImjynVIejSX07NHgla3mQP0bIniZA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-compat": "0.1.13",
@@ -1544,13 +1504,13 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.3.0.tgz",
-      "integrity": "sha512-A0wgMLEjyVyUE+heyMJYqHRkPVjpebhOYsa47RHdrTM4ltApcx8Tn86sUmjqxlfh09gNnILAm7a8q5+FmgBYpg==",
-      "peer": true,
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.1.tgz",
+      "integrity": "sha512-rL3wlZbi2Kb/KJgcmj1YHlD4ZhfmhfgRO2YJialxAllm0tj1IQea878hHuBLGmv4DpbW9t9nLvX9kddNR2Y65Q==",
+      "dev": true,
       "dependencies": {
         "@fastify/busboy": "^1.1.0",
-        "@firebase/database-compat": "^0.2.0",
+        "@firebase/database-compat": "^0.2.3",
         "@firebase/database-types": "^0.9.7",
         "@types/node": ">=12.12.47",
         "jsonwebtoken": "^8.5.1",
@@ -1559,62 +1519,61 @@
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=14"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^4.15.1",
-        "@google-cloud/storage": "^5.18.3"
+        "@google-cloud/firestore": "^5.0.2",
+        "@google-cloud/storage": "^6.1.0"
       }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+      "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.6.7"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1623,7 +1582,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1640,32 +1599,32 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
-      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.5.1.tgz",
+      "integrity": "sha512-7jNMDRhenfw2HLfL9m0ZP/Jw5hzXygfSprzBdypG3rZ+q2gIUbVC/osrFB7y/Z5dkrUr1mnLoDNlerF+p6VXZA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.1.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/google-gax": {
       "version": "2.30.5",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
       "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@grpc/grpc-js": "~1.6.0",
         "@grpc/proto-loader": "^0.6.12",
@@ -1688,12 +1647,64 @@
         "node": ">=10"
       }
     },
-    "node_modules/google-p12-pem": {
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-p12-pem": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
       "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-forge": "^1.3.1"
       },
@@ -1704,19 +1715,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/gtoken": {
+    "node_modules/google-gax/node_modules/gtoken": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
       "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.1.3",
@@ -1726,25 +1730,63 @@
         "node": ">=10"
       }
     },
-    "node_modules/hash-stream-validation": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
+    "node_modules/google-gax/node_modules/retry-request": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "dev": true,
       "optional": true,
-      "peer": true
+      "dependencies": {
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/google-p12-pem": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "node-forge": "^1.3.1"
+      },
+      "bin": {
+        "gp12-pem": "build/src/bin/gp12-pem.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.1.tgz",
+      "integrity": "sha512-HPM4VzzPEGxjQ7T2xLrdSYBs+h1c0yHAUiN+8RHPDoiZbndlpg9Sx3SjWcrTt9+N3FHsSABEpjvdQVan5AAuZQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -1758,8 +1800,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -1772,29 +1814,19 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
       "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "peer": true
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1804,23 +1836,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1829,8 +1851,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -1842,27 +1864,20 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/jose": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
       "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@panva/asn1.js": "^1.0.0"
       },
@@ -1877,14 +1892,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "peer": true
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -1893,7 +1909,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -1915,7 +1931,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -1926,7 +1942,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -1936,7 +1952,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
       "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -1948,7 +1964,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1963,13 +1979,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/jszip/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1978,8 +1994,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -1990,7 +2006,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.1.tgz",
       "integrity": "sha512-NdtZuf1pvlnWgbCU2c9oRFdi+u8uWpwL6EMiordpasrNFNrGrQGNs7WQ9UiMT0/RG7vt4ElwyObNy04pIbsGCA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/express": "^4.17.13",
         "debug": "^4.3.4",
@@ -2006,8 +2022,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -2017,7 +2033,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -2026,72 +2042,73 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "peer": true
+      "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "peer": true
+      "dev": true
     },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -2104,7 +2121,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2116,7 +2133,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
       "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -2126,7 +2143,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "pseudomap": "^1.0.1",
         "yallist": "^2.0.0"
@@ -2136,40 +2153,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "peer": true
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
+      "dev": true
     },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -2181,8 +2172,8 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2191,8 +2182,8 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2204,7 +2195,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2216,13 +2207,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "peer": true,
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2234,7 +2225,7 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/next/-/next-12.2.3.tgz",
       "integrity": "sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@next/env": "12.2.3",
         "@swc/helpers": "0.4.3",
@@ -2287,7 +2278,7 @@
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.10.2.tgz",
       "integrity": "sha512-9XeP3faA5M3LneNJuzZCrmyR1ONYVH+pNQTozLBlpzXSkVRCgy+PTLAojOGkCo5v5MWcCZNTNHUOQL6gIcYwEQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",
@@ -2317,7 +2308,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
       "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2326,7 +2317,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2346,7 +2337,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -2355,14 +2346,14 @@
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
-      "peer": true
+      "dev": true
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2371,7 +2362,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
       "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -2380,7 +2371,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2389,7 +2380,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
       "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
@@ -2407,7 +2398,7 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
       "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2416,7 +2407,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2425,8 +2416,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2441,13 +2432,13 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2456,12 +2447,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
       "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2472,7 +2464,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -2486,7 +2477,7 @@
       "version": "10.7.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
       "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==",
-      "peer": true,
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2496,7 +2487,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.0.tgz",
       "integrity": "sha512-+RGwSW78Cl+NsZRUbFW1MGB++didsfqRk+IyRVTaqy+3OjtpKK/6HgBtfszUX0YXMfo41k2iaQSseAHGKEwrbg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -2508,26 +2499,26 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-      "peer": true
+      "dev": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "peer": true
+      "dev": true
     },
     "node_modules/promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
       "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/proto3-json-serializer": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
       "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "protobufjs": "^6.11.2"
       }
@@ -2536,8 +2527,8 @@
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
       "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2562,35 +2553,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "peer": true
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/pumpify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "duplexify": "^4.1.1",
-        "inherits": "^2.0.3",
-        "pump": "^3.0.0"
-      }
+      "dev": true
     },
     "node_modules/react": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2603,6 +2572,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -2616,8 +2586,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2631,13 +2601,13 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2646,31 +2616,31 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/retry-request": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "extend": "^3.0.2"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=12"
       }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2685,6 +2655,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2698,13 +2669,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/scheduler": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
       "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "dev": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2714,7 +2685,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.1.2.tgz",
       "integrity": "sha512-e4Ap8vQvhipgBB8Ry9zBiKGkU6kHKyNnWiavGGLKkrdW81Zv7NVMtFOL/j3yX0G8QScM7XIXijKssNd4EUxSOw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "jszip": "^3.6.0",
         "tmp": "^0.2.1",
@@ -2728,7 +2699,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "peer": true,
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -2737,20 +2708,13 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "peer": true
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2759,8 +2723,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -2769,15 +2733,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2786,7 +2750,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2800,7 +2764,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2812,14 +2776,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/styled-jsx": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2836,11 +2800,11 @@
       }
     },
     "node_modules/teeny-request": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
-      "integrity": "sha512-SyY0pek1zWsi0LRVAALem+avzMLc33MKW/JLLakdP4s9+D7+jHcy5x6P+h94g2QNZsAqQNfX5lsbd3WSeJXrrw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.1.tgz",
+      "integrity": "sha512-q1yTwqoS5aH1pjur3kBbI+wFpiAswdVirHMB3pYT5x/B0d+ulYdrruB/xVtbTEaxJemHu5aTbh11rsOLlFk/ZQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -2849,20 +2813,20 @@
         "uuid": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/text-decoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
       "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -2874,42 +2838,19 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "peer": true
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "dev": true
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -2918,13 +2859,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true,
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2933,13 +2874,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
       "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -2953,7 +2894,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2962,13 +2903,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "peer": true
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -2978,7 +2919,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2995,26 +2936,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "peer": true
-    },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3031,21 +2959,11 @@
         }
       }
     },
-    "node_modules/xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3054,13 +2972,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "peer": true
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -3078,7 +2996,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3087,8 +3005,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3102,7 +3020,7 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
       "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -3111,7 +3029,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.1.0.tgz",
       "integrity": "sha512-Fv854f94v0CzIDllbY3i/0NJPNBRNLDawf3BTYVGCe9VrIIs3Wi7AFx24F9NzCxdf0wyx/x0Q9kEVnvDOPnlxA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "text-decoding": "^1.0.0"
       }
@@ -3120,7 +3038,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.8.0.tgz",
       "integrity": "sha512-wkcwainNm8Cu2xkJpDSHfhBSdDJn86Q1TZNmLWc67VrhZUHXIKXxIqb65/tNUVE+I8+sFiDDNwA+9R3MqTQTaA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -3133,7 +3051,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.1.13.tgz",
       "integrity": "sha512-QC1DH/Dwc8fBihn0H+jocBWyE17GF1fOCpCrpAiQ2u16F/NqsVDVG4LjIqdhq963DXaXneNY7oDwa25Up682AA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-types": "0.7.0",
@@ -3146,13 +3064,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.7.0.tgz",
       "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==",
-      "peer": true
+      "dev": true
     },
     "@firebase/app": {
       "version": "0.7.29",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.29.tgz",
       "integrity": "sha512-jT47plTi/O0lpXEXPx5t/dH/3BVnP9Tq/D8SZkhMUXPYlYDudvepIiV3VOW8XxbbHU/X+JyY0qG5CoWxIk0teg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3165,7 +3083,7 @@
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.12.tgz",
       "integrity": "sha512-l+MmvupSGT/F+I5ei7XjhEfpoL4hLVJr0vUwcG5NEf2hAkQnySli9fnbl9fZu1BJaQ2kthrMmtg1gcbcM9BUCQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3177,7 +3095,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.12.tgz",
       "integrity": "sha512-GFppNLlUyMN9Iq31ME/+GkjRVKlc+MeanzUKQ9UaR73ZsYH3oX3Ja+xjoYgixaVJDDG+ofBYR7ZXTkkQdSR/pw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/app-check": "0.5.12",
         "@firebase/app-check-types": "0.4.0",
@@ -3191,19 +3109,19 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
       "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
-      "peer": true
+      "dev": true
     },
     "@firebase/app-check-types": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.4.0.tgz",
       "integrity": "sha512-SsWafqMABIOu7zLgWbmwvHGOeQQVQlwm42kwwubsmfLmL4Sf5uGpBfDhQ0CAkpi7bkJ/NwNFKafNDL9prRNP0Q==",
-      "peer": true
+      "dev": true
     },
     "@firebase/app-compat": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.30.tgz",
       "integrity": "sha512-t51oJEJzjts4D5C7Nol0Ua7dqhpQSlcWSa7X1VtL+zjcTZ92ibYmwQjXomexBmlKvCUamGClMAEBfEgUtr0Wug==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/app": "0.7.29",
         "@firebase/component": "0.5.17",
@@ -3216,13 +3134,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
       "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
-      "peer": true
+      "dev": true
     },
     "@firebase/auth": {
       "version": "0.20.5",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.20.5.tgz",
       "integrity": "sha512-SbKj7PCAuL0lXEToUOoprc1im2Lr/bzOePXyPC7WWqVgdVBt0qovbfejlzKYwJLHUAPg9UW1y3XYe3IlbXr77w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3236,7 +3154,7 @@
       "version": "0.2.18",
       "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.2.18.tgz",
       "integrity": "sha512-Fw2PJS0G/tGrfyEBcYJQ42sfy5+sANrK5xd7tuzgV7zLFW5rYkHUIZngXjuOBwLOcfO2ixa/FavfeJle3oJ38Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/auth": "0.20.5",
         "@firebase/auth-types": "0.11.0",
@@ -3251,21 +3169,21 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
       "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "@firebase/auth-types": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
       "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "@firebase/component": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
       "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
@@ -3275,7 +3193,7 @@
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.3.tgz",
       "integrity": "sha512-ZE+QJqQUaCTZiIzGq3RJLo64HRMtbdaEwyDhfZyPEzMJV4kyLsw3cHdEHVCtBmdasTvwtpO2YRFmd4AXAoKtNw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/auth-interop-types": "0.1.6",
         "@firebase/component": "0.5.17",
@@ -3289,7 +3207,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.3.tgz",
       "integrity": "sha512-uwSMnbjlSQM5gQRq8OoBLs7uc7obwsl0D6kSDAnMOlPtPl9ert79Rq9faU/COjybsJ8l7tNXMVYYJo3mQ5XNrA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/database": "0.13.3",
@@ -3303,7 +3221,7 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.11.tgz",
       "integrity": "sha512-27V3eFomWCZqLR6qb3Q9eS2lsUtulhSHeDNaL6fImwnhvMYTmf6ZwMfRWupgi8AFwW4s91g9Oc1/fkQtJGHKQw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/app-types": "0.7.0",
         "@firebase/util": "1.6.3"
@@ -3313,7 +3231,7 @@
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.13.tgz",
       "integrity": "sha512-wLsbWflFoWDg9NprulzTAjtapLA3dfaG1Dsa9OUsgPRDGg5jfeo60n43d94fesX4crE+C5vkFhLQKMgsEGpr9w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3329,7 +3247,7 @@
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.22.tgz",
       "integrity": "sha512-1HWmJtbxhDzAV7984XSQX7tp0MzjhRFnBygpU6k6H2m0Ey9JVDTPK8lIlZCctjCCA2cBsek7yAD+rDnpWC+KRw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/firestore": "3.4.13",
@@ -3342,14 +3260,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
       "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "@firebase/functions": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.8.4.tgz",
       "integrity": "sha512-o1bB0xMyQKe+b246zGnjwHj4R6BH4mU2ZrSaa/3QvTpahUQ3hqYfkZPLOXCU7+vEFxHb3Hd4UUjkFhxoAcPqLA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/app-check-interop-types": "0.1.0",
         "@firebase/auth-interop-types": "0.1.6",
@@ -3364,7 +3282,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.2.4.tgz",
       "integrity": "sha512-Crfn6il1yXGuXkjSd8nKrqR4XxPvuP19g64bXpM6Ix67qOkQg676kyOuww0FF17xN0NSXHfG8Pyf+CUrx8wJ5g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/functions": "0.8.4",
@@ -3377,13 +3295,13 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.0.tgz",
       "integrity": "sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==",
-      "peer": true
+      "dev": true
     },
     "@firebase/installations": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.5.12.tgz",
       "integrity": "sha512-Zq43fCE0PB5tGJ3ojzx5RNQzKdej1188qgAk22rwjuhP7npaG/PlJqDG1/V0ZjTLRePZ1xGrfXSPlA17c/vtNw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/util": "1.6.3",
@@ -3395,7 +3313,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.1.12.tgz",
       "integrity": "sha512-BIhFpWIn/GkuOa+jnXkp3SDJT2RLYJF6MWpinHIBKFJs7MfrgYZ3zQ1AlhobDEql+bkD1dK4dB5sNcET2T+EyA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -3408,14 +3326,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.4.0.tgz",
       "integrity": "sha512-nXxWKQDvBGctuvsizbUEJKfxXU9WAaDhon+j0jpjIfOJkvkj3YHqlLB/HeYjpUn85Pb22BjplpTnDn4Gm9pc3A==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "@firebase/logger": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
       "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -3424,7 +3342,7 @@
       "version": "0.9.16",
       "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.9.16.tgz",
       "integrity": "sha512-Yl9gGrAvJF6C1gg3+Cr2HxlL6APsDEkrorkFafmSP1l+rg1epZKoOAcKJbSF02Vtb50wfb9FqGGy8tzodgETxg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -3438,7 +3356,7 @@
       "version": "0.1.16",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.1.16.tgz",
       "integrity": "sha512-uG7rWcXJzU8vvlEBFpwG1ndw/GURrrmKcwsHopEWbsPGjMRaVWa7XrdKbvIR7IZohqPzcC/V9L8EeqF4Q4lz8w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/messaging": "0.9.16",
@@ -3450,13 +3368,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz",
       "integrity": "sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==",
-      "peer": true
+      "dev": true
     },
     "@firebase/performance": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.5.12.tgz",
       "integrity": "sha512-MPVTkOkGrm2SMQgI1FPNBm85y2pPqlPb6VDjIMCWkVpAr6G1IZzUT24yEMySRcIlK/Hh7/Qu1Nu5ASRzRuX6+Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -3469,7 +3387,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.1.12.tgz",
       "integrity": "sha512-IBORzUeGY1MGdZnsix9Mu5z4+C3WHIwalu0usxvygL0EZKHztGG8bppYPGH/b5vvg8QyHs9U+Pn1Ot2jZhffQQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3483,13 +3401,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.1.0.tgz",
       "integrity": "sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==",
-      "peer": true
+      "dev": true
     },
     "@firebase/polyfill": {
       "version": "0.3.36",
       "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
       "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "core-js": "3.6.5",
         "promise-polyfill": "8.1.3",
@@ -3500,7 +3418,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.3.11.tgz",
       "integrity": "sha512-qA84dstrvVpO7rWT/sb2CLv1kjHVmz59SRFPKohJJYFBcPOGK4Pe4FWWhKAE9yg1Gnl0qYAGkahOwNawq3vE0g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/installations": "0.5.12",
@@ -3513,7 +3431,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.1.12.tgz",
       "integrity": "sha512-Yz7Gtb2rLa7ykXZX9DnSTId8CXd++jFFLW3foUImrYwJEtWgLJc7gwkRfd1M73IlKGNuQAY+DpUNF0n1dLbecA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -3527,13 +3445,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz",
       "integrity": "sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==",
-      "peer": true
+      "dev": true
     },
     "@firebase/storage": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.9.9.tgz",
       "integrity": "sha512-Zch7srLT2SIh9y2nCVv/4Kne0HULn7OPkmreY70BJTUJ+g5WLRjggBq6x9fV5ls9V38iqMWfn4prxzX8yIc08A==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/util": "1.6.3",
@@ -3545,7 +3463,7 @@
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.1.17.tgz",
       "integrity": "sha512-nOYmnpI0gwoz5nROseMi9WbmHGf+xumfsOvdPyMZAjy0VqbDnpKIwmTUZQBdR+bLuB5oIkHQsvw9nbb1SH+PzQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/storage": "0.9.9",
@@ -3558,14 +3476,14 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
       "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "@firebase/util": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
       "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -3574,14 +3492,14 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.6.2.tgz",
       "integrity": "sha512-zThUKcqIU6utWzM93uEvhlh8qj8A5LMPFJPvk/ODb+8GSSif19xM2Lw1M2ijyBy8+6skSkQBbavPzOU5Oh/8tQ==",
-      "peer": true
+      "dev": true
     },
     "@google-cloud/firestore": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-4.15.1.tgz",
-      "integrity": "sha512-2PWsCkEF1W02QbghSeRsNdYKN1qavrHBP3m72gPDMHQSYrGULOaTi7fSJquQmAtc4iPVB2/x6h80rdLHTATQtA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-5.0.2.tgz",
+      "integrity": "sha512-xlGcNYaW0nvUMzNn2+pLfbEBVt6oysVqtM89faMgZWkWfEtvIQGS0h5PRdLlcqufNzRCX3yIGv29Pb+03ys+VA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
@@ -3593,64 +3511,59 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
       "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       }
     },
     "@google-cloud/projectify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
-      "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
-      "optional": true,
-      "peer": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
+      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+      "dev": true,
+      "optional": true
     },
     "@google-cloud/promisify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
-      "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
-      "optional": true,
-      "peer": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.0.tgz",
+      "integrity": "sha512-91ArYvRgXWb73YvEOBMmOcJc0bDRs5yiVHnqkwoG0f3nm7nZuipllz6e7BvFESBvjkDTBC0zMD8QxedUwNLc1A==",
+      "dev": true,
+      "optional": true
     },
     "@google-cloud/storage": {
-      "version": "5.20.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.20.5.tgz",
-      "integrity": "sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.4.2.tgz",
+      "integrity": "sha512-rnwx++XIxy63t1CREGlY2+H+tvuvYmkiIqJdq0IRzGaah9bDetV+qJVl5Mvi5aPhgoqn3UNnKGv9SPcETimFgw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@google-cloud/paginator": "^3.0.7",
-        "@google-cloud/projectify": "^2.0.0",
-        "@google-cloud/promisify": "^2.0.0",
+        "@google-cloud/projectify": "^3.0.0",
+        "@google-cloud/promisify": "^3.0.0",
         "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
         "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
-        "configstore": "^5.0.0",
         "duplexify": "^4.0.0",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.14.1",
-        "hash-stream-validation": "^0.2.2",
+        "gaxios": "^5.0.0",
+        "google-auth-library": "^8.0.1",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
-        "pumpify": "^2.0.0",
-        "retry-request": "^4.2.2",
-        "stream-events": "^1.0.4",
-        "teeny-request": "^7.1.3",
-        "uuid": "^8.0.0",
-        "xdg-basedir": "^4.0.0"
+        "retry-request": "^5.0.0",
+        "teeny-request": "^8.0.0",
+        "uuid": "^8.0.0"
       }
     },
     "@grpc/grpc-js": {
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.8.tgz",
       "integrity": "sha512-Nt5tufF/O5Q310kP0cDzxznWMZW58GCTZhUUiAQ9B0K0ANKNQ4Lj/K9XK0vZg+UBKq5/7z7+8mXHHfrcwoeFJQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -3660,7 +3573,7 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
           "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "@types/long": "^4.0.1",
             "lodash.camelcase": "^4.3.0",
@@ -3673,7 +3586,7 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
           "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -3694,7 +3607,7 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
               "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==",
-              "peer": true
+              "dev": true
             }
           }
         }
@@ -3704,7 +3617,7 @@
       "version": "0.6.13",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
       "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -3717,140 +3630,140 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
       "integrity": "sha512-2lWKP5Xcvnor70NaaROZXBvU8z9mFReePCG8NhZw6NyNGnPvC+8s+Cre/63LAB1LKzWw/e9bZJnQUg0gYFRb2Q==",
-      "peer": true
+      "dev": true
     },
     "@next/swc-android-arm-eabi": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.2.3.tgz",
       "integrity": "sha512-JxmCW9XB5PYnkGE67BdnBTdqW0SW6oMCiPMHLdjeRi4T3U4JJKJGnjQld99+6TPOfPWigtw3W7Cijp5gc+vJ/w==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-android-arm64": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.2.3.tgz",
       "integrity": "sha512-3l4zXpWnzy0fqoedsFRxzMy/eGlMMqn6IwPEuBmtEQ4h7srmQFHyT+Bk+eVHb0o1RQ7/TloAa+mu8JX5tz/5tA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-darwin-arm64": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.2.3.tgz",
       "integrity": "sha512-eutDO/RH6pf7+8zHo3i2GKLhF0qaMtxWpY8k3Oa1k+CyrcJ0IxwkfH/x3f75jTMeCrThn6Uu8j3WeZOxvhto1Q==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-darwin-x64": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.2.3.tgz",
       "integrity": "sha512-lve+lnTiddXbcT3Lh2ujOFywQSEycTYQhuf6j6JrPu9oLQGS01kjIqqSj3/KMmSoppEnXo3BxkgYu+g2+ecHkA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-freebsd-x64": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.3.tgz",
       "integrity": "sha512-V4bZU1qBFkULTPW53phY8ypioh3EERzHu9YKAasm9RxU4dj+8c/4s60y+kbFkFEEpIUgEU6yNuYZRR4lHHbUGA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.2.3.tgz",
       "integrity": "sha512-MWxS/i+XSEKdQE0ZmdYkPPrWKBi4JwMVaXdOW9J/T/sZJsHsLlSC9ErBcNolKAJEVka+tnw9oPRyRCKOj+q0sw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.2.3.tgz",
       "integrity": "sha512-ikXkqAmvEcWTzIQFDdmrUHLWzdDAF5s2pVsSpQn9rk/gK1i9webH1GRQd2bSM7JLuPBZSaYrNGvDTyHZdSEYlg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-arm64-musl": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.2.3.tgz",
       "integrity": "sha512-wE45gGFkeLLLnCoveKaBrdpYkkypl3qwNF2YhnfvfVK7etuu1O679LwClhCWinDVBr+KOkmyHok00Z+0uI1ycg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-x64-gnu": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.2.3.tgz",
       "integrity": "sha512-MbFI6413VSXiREzHwYD8YAJLTknBaC+bmjXgdHEEdloeOuBFQGE3NWn3izOCTy8kV+s98VDQO8au7EKKs+bW0g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-linux-x64-musl": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.2.3.tgz",
       "integrity": "sha512-jMBD0Va6fInbPih/dNySlNY2RpjkK6MXS+UGVEvuTswl1MZr+iahvurmshwGKpjaRwVU4DSFMD8+gfWxsTFs1Q==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.2.3.tgz",
       "integrity": "sha512-Cq8ToPdc0jQP2C7pjChYctAsEe7+lO/B826ZCK5xFzobuHPiCyJ2Mzx/nEQwCY4SpYkeJQtCbwlCz5iyGW5zGg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.2.3.tgz",
       "integrity": "sha512-BtFq4c8IpeB0sDhJMHJFgm86rPkOvmYI8k3De8Y2kgNVWSeLQ0Q929PWf7e+GqcX1015ei/gEB41ZH8Iw49NzA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.2.3.tgz",
       "integrity": "sha512-huSNb98KSG77Kl96CoPgCwom28aamuUsPpRmn/4s9L0RNbbHVSkp9E6HA4yOAykZCEuWcdNsRLbVVuAbt8rtIw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@panva/asn1.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "peer": true
+      "dev": true
     },
     "@panva/hkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.2.tgz",
       "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3860,37 +3773,37 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "peer": true
+      "dev": true
     },
     "@swc/helpers": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
       "integrity": "sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -3899,14 +3812,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -3916,7 +3829,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -3925,7 +3838,7 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -3937,7 +3850,7 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3948,37 +3861,37 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "peer": true
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "peer": true
+      "dev": true
     },
     "@types/node": {
       "version": "17.0.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
       "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
-      "peer": true
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "peer": true
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "peer": true
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -3988,8 +3901,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -3998,8 +3911,8 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "debug": "4"
       }
@@ -4008,13 +3921,13 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "peer": true
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -4023,15 +3936,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "retry": "0.13.1"
       }
@@ -4040,27 +3953,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "peer": true
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "optional": true,
-      "peer": true
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+      "dev": true,
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4070,19 +3983,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "peer": true
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001339",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
       "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
-      "peer": true
+      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4093,7 +4006,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -4102,14 +4015,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
+      "dev": true
     },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
       }
@@ -4118,73 +4031,41 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "peer": true
-    },
-    "configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      }
+      "dev": true
     },
     "cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "peer": true
+      "dev": true
     },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-      "peer": true
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "peer": true
-    },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
-      }
-    },
-    "dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "is-obj": "^2.0.0"
       }
     },
     "duplexify": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
       "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -4196,7 +4077,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4205,14 +4086,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "peer": true
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -4221,48 +4102,48 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "peer": true
+      "dev": true
     },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "fast-text-encoding": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
-      "integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
-      "optional": true,
-      "peer": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
+      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
+      "dev": true,
+      "optional": true
     },
     "faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
       "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -4271,7 +4152,7 @@
       "version": "9.9.1",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.1.tgz",
       "integrity": "sha512-1saLd91mmfNWOdP3DpkCAyXcrwB0iJXZoYY8S98ljp1erL+eUPHu+AHw8ImjynVIejSX07NHgla3mQP0bIniZA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-compat": "0.1.13",
@@ -4303,16 +4184,16 @@
       }
     },
     "firebase-admin": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.3.0.tgz",
-      "integrity": "sha512-A0wgMLEjyVyUE+heyMJYqHRkPVjpebhOYsa47RHdrTM4ltApcx8Tn86sUmjqxlfh09gNnILAm7a8q5+FmgBYpg==",
-      "peer": true,
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.0.1.tgz",
+      "integrity": "sha512-rL3wlZbi2Kb/KJgcmj1YHlD4ZhfmhfgRO2YJialxAllm0tj1IQea878hHuBLGmv4DpbW9t9nLvX9kddNR2Y65Q==",
+      "dev": true,
       "requires": {
         "@fastify/busboy": "^1.1.0",
-        "@firebase/database-compat": "^0.2.0",
+        "@firebase/database-compat": "^0.2.3",
         "@firebase/database-types": "^0.9.7",
-        "@google-cloud/firestore": "^4.15.1",
-        "@google-cloud/storage": "^5.18.3",
+        "@google-cloud/firestore": "^5.0.2",
+        "@google-cloud/storage": "^6.1.0",
         "@types/node": ">=12.12.47",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
@@ -4324,23 +4205,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "peer": true
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.1.tgz",
+      "integrity": "sha512-keK47BGKHyyOVQxgcUaSaFvr3ehZYAlvhvpHXy0YB2itzZef+GqZR8TBsfVRWghdwlKrYsn+8L8i3eblF7Oviw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
-        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
@@ -4348,13 +4228,13 @@
       }
     },
     "gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
       }
     },
@@ -4362,13 +4242,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "peer": true
+      "dev": true
     },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4379,19 +4259,19 @@
       }
     },
     "google-auth-library": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
-      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.5.1.tgz",
+      "integrity": "sha512-7jNMDRhenfw2HLfL9m0ZP/Jw5hzXygfSprzBdypG3rZ+q2gIUbVC/osrFB7y/Z5dkrUr1mnLoDNlerF+p6VXZA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^6.1.0",
         "jws": "^4.0.0",
         "lru-cache": "^6.0.0"
       }
@@ -4400,8 +4280,8 @@
       "version": "2.30.5",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.30.5.tgz",
       "integrity": "sha512-Jey13YrAN2hfpozHzbtrwEfEHdStJh1GwaQ2+Akh1k0Tv/EuNVSuBtHZoKSBm5wBMvNsxTsEIZ/152NrYyZgxQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@grpc/grpc-js": "~1.6.0",
         "@grpc/proto-loader": "^0.6.12",
@@ -4416,56 +4296,120 @@
         "proto3-json-serializer": "^0.1.8",
         "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+          "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+          "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "gaxios": "^4.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+          "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+          "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "node-forge": "^1.3.1"
+          }
+        },
+        "gtoken": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+          "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "gaxios": "^4.0.0",
+            "google-p12-pem": "^3.1.3",
+            "jws": "^4.0.0"
+          }
+        },
+        "retry-request": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+          "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "extend": "^3.0.2"
+          }
+        }
       }
     },
     "google-p12-pem": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
-      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
+      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "node-forge": "^1.3.1"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "optional": true,
-      "peer": true
-    },
     "gtoken": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.1.tgz",
+      "integrity": "sha512-HPM4VzzPEGxjQ7T2xLrdSYBs+h1c0yHAUiN+8RHPDoiZbndlpg9Sx3SjWcrTt9+N3FHsSABEpjvdQVan5AAuZQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.1.3",
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
         "jws": "^4.0.0"
       }
-    },
-    "hash-stream-validation": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
-      "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
-      "optional": true,
-      "peer": true
     },
     "http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
-      "peer": true
+      "dev": true
     },
     "http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -4476,8 +4420,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -4487,26 +4431,19 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
       "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg==",
-      "peer": true
+      "dev": true
     },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "peer": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4516,53 +4453,39 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "peer": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "peer": true
-    },
-    "is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "is-stream-ended": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-      "optional": true,
-      "peer": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "peer": true
+      "dev": true
     },
     "jose": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
       "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -4571,14 +4494,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "peer": true
     },
     "json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "bignumber.js": "^9.0.0"
       }
@@ -4587,7 +4511,7 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -4605,7 +4529,7 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
           "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "buffer-equal-constant-time": "1.0.1",
             "ecdsa-sig-formatter": "1.0.11",
@@ -4616,7 +4540,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
           "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "jwa": "^1.4.1",
             "safe-buffer": "^5.0.1"
@@ -4628,7 +4552,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
       "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -4640,7 +4564,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4655,13 +4579,13 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "peer": true
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4672,8 +4596,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4684,7 +4608,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.1.tgz",
       "integrity": "sha512-NdtZuf1pvlnWgbCU2c9oRFdi+u8uWpwL6EMiordpasrNFNrGrQGNs7WQ9UiMT0/RG7vt4ElwyObNy04pIbsGCA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@types/express": "^4.17.13",
         "debug": "^4.3.4",
@@ -4697,8 +4621,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -4708,7 +4632,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -4717,72 +4641,73 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "peer": true
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "peer": true
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "peer": true
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "peer": true
+      "dev": true
     },
     "lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
-      "peer": true
+      "dev": true
     },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "peer": true
+      "dev": true
     },
     "lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
-      "peer": true
+      "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "peer": true
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "peer": true
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "peer": true
+      "dev": true
     },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "peer": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4792,7 +4717,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -4801,7 +4726,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
       "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -4811,7 +4736,7 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
           "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-          "peer": true,
+          "dev": true,
           "requires": {
             "pseudomap": "^1.0.1",
             "yallist": "^2.0.0"
@@ -4821,26 +4746,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "peer": true
-        }
-      }
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "optional": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -4848,22 +4754,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -4872,7 +4778,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4881,19 +4787,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "peer": true
+      "dev": true
     },
     "next": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/next/-/next-12.2.3.tgz",
       "integrity": "sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@next/env": "12.2.3",
         "@next/swc-android-arm-eabi": "12.2.3",
@@ -4920,7 +4826,7 @@
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.10.2.tgz",
       "integrity": "sha512-9XeP3faA5M3LneNJuzZCrmyR1ONYVH+pNQTozLBlpzXSkVRCgy+PTLAojOGkCo5v5MWcCZNTNHUOQL6gIcYwEQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",
@@ -4937,7 +4843,7 @@
           "version": "4.8.1",
           "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
           "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -4945,7 +4851,7 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -4954,32 +4860,32 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "peer": true
+      "dev": true
     },
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
-      "peer": true
+      "dev": true
     },
     "object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "oidc-token-hash": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
       "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
-      "peer": true
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4988,7 +4894,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.5.tgz",
       "integrity": "sha512-m41p7V/iXyqc0WZeo20uwKk8NPDAtYd3JS0uWjttcqwvFo4YNYAKegMAMea1qG5RClddQ6rV9ec/TP6ZvsCrYw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
@@ -5000,13 +4906,13 @@
           "version": "4.8.1",
           "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
           "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
-          "peer": true
+          "dev": true
         },
         "object-hash": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
           "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -5014,8 +4920,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -5024,25 +4930,25 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "peer": true
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "peer": true
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "peer": true
+      "dev": true
     },
     "postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
       "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -5053,13 +4959,13 @@
       "version": "10.7.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.2.tgz",
       "integrity": "sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==",
-      "peer": true
+      "dev": true
     },
     "preact-render-to-string": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.0.tgz",
       "integrity": "sha512-+RGwSW78Cl+NsZRUbFW1MGB++didsfqRk+IyRVTaqy+3OjtpKK/6HgBtfszUX0YXMfo41k2iaQSseAHGKEwrbg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "pretty-format": "^3.8.0"
       }
@@ -5068,26 +4974,26 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-      "peer": true
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "peer": true
+      "dev": true
     },
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
       "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-      "peer": true
+      "dev": true
     },
     "proto3-json-serializer": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-0.1.9.tgz",
       "integrity": "sha512-A60IisqvnuI45qNRygJjrnNjX2TMdQGMY+57tR3nul3ZgO2zXkR9OGR8AXxJhkqx84g0FTnrfi3D5fWMSdANdQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "protobufjs": "^6.11.2"
       }
@@ -5096,7 +5002,7 @@
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
       "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5117,35 +5023,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "peer": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
-      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "duplexify": "^4.1.1",
-        "inherits": "^2.0.3",
-        "pump": "^3.0.0"
-      }
+      "dev": true
     },
     "react": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
@@ -5155,6 +5039,7 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -5165,8 +5050,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5177,27 +5062,27 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "peer": true
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "peer": true
+      "dev": true
     },
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "retry-request": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
-      "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.1.tgz",
+      "integrity": "sha512-lxFKrlBt0OZzCWh/V0uPEN0vlr3OhdeXnpeY5OES+ckslm791Cb1D5P7lJUSnY7J5hiCjcyaUGmzCnIGDCUBig==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "debug": "^4.1.1",
         "extend": "^3.0.2"
@@ -5207,7 +5092,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -5216,12 +5101,13 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "peer": true
+      "dev": true
     },
     "scheduler": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
       "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "dev": true,
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
@@ -5231,7 +5117,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.1.2.tgz",
       "integrity": "sha512-e4Ap8vQvhipgBB8Ry9zBiKGkU6kHKyNnWiavGGLKkrdW81Zv7NVMtFOL/j3yX0G8QScM7XIXijKssNd4EUxSOw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "jszip": "^3.6.0",
         "tmp": "^0.2.1",
@@ -5242,33 +5128,26 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "peer": true
+      "dev": true
     },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "peer": true
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "peer": true
+      "dev": true
     },
     "stream-events": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -5277,15 +5156,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -5294,7 +5173,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5305,7 +5184,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -5314,22 +5193,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     },
     "styled-jsx": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
       "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "teeny-request": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
-      "integrity": "sha512-SyY0pek1zWsi0LRVAALem+avzMLc33MKW/JLLakdP4s9+D7+jHcy5x6P+h94g2QNZsAqQNfX5lsbd3WSeJXrrw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.1.tgz",
+      "integrity": "sha512-q1yTwqoS5aH1pjur3kBbI+wFpiAswdVirHMB3pYT5x/B0d+ulYdrruB/xVtbTEaxJemHu5aTbh11rsOLlFk/ZQ==",
+      "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -5342,13 +5221,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
       "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
-      "peer": true
+      "dev": true
     },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "rimraf": "^3.0.0"
       }
@@ -5357,64 +5236,44 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "dev": true
     },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "peer": true
-    },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
+      "dev": true
     },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peer": true,
+      "dev": true,
       "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "peer": true
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
       "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -5425,19 +5284,19 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "peer": true
+      "dev": true
     },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "peer": true
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5447,7 +5306,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5458,52 +5317,32 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "peer": true
-    },
-    "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
+      "dev": true
     },
     "ws": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
       "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
-      "peer": true,
+      "dev": true,
       "requires": {}
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "optional": true,
-      "peer": true
     },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "peer": true
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "peer": true
+      "dev": true
     },
     "yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -5518,14 +5357,14 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "peer": true
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "optional": true,
-      "peer": true
+      "dev": true,
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "peerDependencies": {
     "firebase": "^9.x",
-    "next": "^12.x",
     "firebase-admin": "^10.x",
+    "next": "^12.x",
     "next-auth": "^4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lowfront/firebase-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Firebase adapter for NextAuth.js using Firebase auth's CustomToken authentication method.",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -80,7 +80,10 @@ export default function FirestoreAdapter(
       const { id, ...userData } = data;
       await findUserDoc(id as string).set(userData, { merge: true });
       const userSnap = await findUserDoc(id as string).get();
-      const user = userSnap.data() as AdapterUser;
+      const user = {
+        id: userSnap.id,
+        ...userSnap.data()
+      } as AdapterUser;
       return user;
     },
     async deleteUser(id) {

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -7,7 +7,7 @@ import { FirebaseAdapterProps } from "../types";
 export default function FirestoreAdapter(
   db: Firestore,
   options: FirebaseAdapterProps = {},
-): Adapter {  
+): Adapter {
   const adapterCollectionName = options.adapterCollectionName ?? '_next_auth_firebase_adapter_';
 
   const userCollectionRef = db.collection(adapterCollectionName).doc('store').collection('user');
@@ -30,7 +30,7 @@ export default function FirestoreAdapter(
         image: data.image ?? null,
         emailVerified: data.emailVerified ?? null,
       };
-      
+
       const userRef = await userCollectionRef.add(userData);
       const user = {
         id: userRef.id,
@@ -42,11 +42,11 @@ export default function FirestoreAdapter(
     async getUser(id) {
       const userSnap = await findUserDoc(id).get();
       if (!userSnap.exists) return null;
-      
+
       const user = userSnap.data() as AdapterUser;
       return user;
     },
-    async getUserByEmail(email) {      
+    async getUserByEmail(email) {
       const q = userCollectionRef.where('email', '==', email).limit(1);
       const userRef = await findOne(q);
 
@@ -57,7 +57,7 @@ export default function FirestoreAdapter(
       } as AdapterUser;
       return user;
     },
-    async getUserByAccount({provider, providerAccountId}) {
+    async getUserByAccount({ provider, providerAccountId }) {
       const q = accountCollectionRef.where('provider', '==', provider).where('providerAccountId', '==', providerAccountId).limit(1);
       const accountRef = await findOne(q);
       if (!accountRef) return null;
@@ -65,7 +65,7 @@ export default function FirestoreAdapter(
         id: accountRef.id,
         ...accountRef.data(),
       } as unknown as Account;
-      
+
       const userRef = await findUserDoc(account.userId as string).get();
       if (!userRef.exists) return null
       const userData = userRef.data();
@@ -78,8 +78,9 @@ export default function FirestoreAdapter(
     },
     async updateUser(data) {
       const { id, ...userData } = data;
-      await findUserDoc(id as string).set(userData);
-      const user = data as AdapterUser;
+      await findUserDoc(id as string).set(userData, { merge: true });
+      const userSnap = await findUserDoc(id as string).get();
+      const user = userSnap.data() as AdapterUser;
       return user;
     },
     async deleteUser(id) {
@@ -110,7 +111,7 @@ export default function FirestoreAdapter(
       const userRef = await findUserDoc(sessionData.userId as string).get();
       if (!userRef.exists) return null
       const userData = userRef.data();
-      
+
       const user = {
         id: userRef.id,
         ...userData,
@@ -151,7 +152,7 @@ export default function FirestoreAdapter(
       const q = sessionCollectionRef.where('sessionToken', '==', sessionToken).limit(1);
       const sessionRef = await findOne(q);
       if (!sessionRef) return;
-      
+
       await Promise.allSettled([
         findSessionDoc(sessionRef.id).delete(),
         findCustomTokenDoc(sessionToken).delete(),

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,7 @@
+export declare type FirebaseAdapterProps = {
+    adapterCollectionName?: string;
+};
+export declare type CustomToken = {
+    token: string;
+    expires: string;
+};

--- a/types.js
+++ b/types.js
@@ -1,0 +1,2 @@
+"use strict";
+exports.__esModule = true;

--- a/web/index.d.ts
+++ b/web/index.d.ts
@@ -1,0 +1,15 @@
+import { FirebaseApp } from "firebase/app";
+import { addDoc as _addDoc, getDoc as _getDoc, getDocs as _getDocs, setDoc as _setDoc, updateDoc as _updateDoc, deleteDoc as _deleteDoc, Query, DocumentData, QueryDocumentSnapshot, Firestore } from "firebase/firestore";
+export declare function signInFirebase(app?: FirebaseApp): Promise<void>;
+export declare function trySignInWithCustomToken<T>(f?: (() => Promise<T>) | Promise<T>, app?: FirebaseApp): Promise<T | undefined>;
+export declare const addDoc: typeof _addDoc;
+export declare const getDoc: typeof _getDoc;
+export declare const getDocs: typeof _getDocs;
+export declare const setDoc: typeof _setDoc;
+export declare const updateDoc: typeof _updateDoc;
+export declare const deleteDoc: typeof _deleteDoc;
+export declare function validCustomToken(db: Firestore, id: string): Promise<import("@firebase/firestore").DocumentSnapshot<DocumentData>>;
+export declare function getUserDoc(db: Firestore, email: string, ...paths: string[]): import("@firebase/firestore").DocumentReference<DocumentData>;
+export declare function getUserCollection(db: Firestore, email: string, ...paths: string[]): import("@firebase/firestore").CollectionReference<DocumentData>;
+export declare function findOne(q: Query<DocumentData>): Promise<QueryDocumentSnapshot<DocumentData> | null>;
+export declare function findMany(q: Query<DocumentData>): Promise<QueryDocumentSnapshot<DocumentData>[]>;

--- a/web/index.js
+++ b/web/index.js
@@ -1,0 +1,177 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+exports.__esModule = true;
+exports.findMany = exports.findOne = exports.getUserCollection = exports.getUserDoc = exports.validCustomToken = exports.deleteDoc = exports.updateDoc = exports.setDoc = exports.getDocs = exports.getDoc = exports.addDoc = exports.trySignInWithCustomToken = exports.signInFirebase = void 0;
+var app_1 = require("firebase/app");
+var auth_1 = require("firebase/auth");
+var firestore_1 = require("firebase/firestore");
+var helper_1 = require("../helper");
+function signInFirebase(app) {
+    if (app === void 0) { app = (0, app_1.getApp)(); }
+    return __awaiter(this, void 0, void 0, function () {
+        var token;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, fetch('/api/auth/firebase-custom-token').then(function (res) { return res.text(); })];
+                case 1:
+                    token = _a.sent();
+                    return [4 /*yield*/, (0, auth_1.signInWithCustomToken)((0, auth_1.getAuth)(app), token)];
+                case 2:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+exports.signInFirebase = signInFirebase;
+function trySignInWithCustomToken(f, app) {
+    if (app === void 0) { app = (0, app_1.getApp)(); }
+    return __awaiter(this, void 0, void 0, function () {
+        var failCount, err_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    failCount = 3;
+                    _a.label = 1;
+                case 1:
+                    if (!failCount--) return [3 /*break*/, 8];
+                    _a.label = 2;
+                case 2:
+                    _a.trys.push([2, 4, , 7]);
+                    return [4 /*yield*/, (typeof f === 'function' ? f() : f)];
+                case 3: return [2 /*return*/, _a.sent()];
+                case 4:
+                    err_1 = _a.sent();
+                    console.error(err_1);
+                    return [4 /*yield*/, signInFirebase(app)];
+                case 5:
+                    _a.sent();
+                    return [4 /*yield*/, (0, helper_1.sleep)(100)];
+                case 6:
+                    _a.sent();
+                    return [3 /*break*/, 7];
+                case 7: return [3 /*break*/, 1];
+                case 8: throw new Error('Fail sign in with custom token.');
+            }
+        });
+    });
+}
+exports.trySignInWithCustomToken = trySignInWithCustomToken;
+exports.addDoc = (function (reference, data) {
+    return trySignInWithCustomToken(function () { return (0, firestore_1.addDoc)(reference, data); });
+});
+exports.getDoc = (function (reference) {
+    return trySignInWithCustomToken(function () { return (0, firestore_1.getDoc)(reference); });
+});
+exports.getDocs = (function (reference) {
+    return trySignInWithCustomToken(function () { return (0, firestore_1.getDocs)(reference); });
+});
+exports.setDoc = (function (reference, data, options) {
+    return trySignInWithCustomToken(function () { return (0, firestore_1.setDoc)(reference, data, options); });
+});
+exports.updateDoc = (function (reference, field, value) {
+    var moreFieldsAndValues = [];
+    for (var _i = 3; _i < arguments.length; _i++) {
+        moreFieldsAndValues[_i - 3] = arguments[_i];
+    }
+    return trySignInWithCustomToken(function () { return firestore_1.updateDoc.apply(void 0, __spreadArray([reference, field, value], moreFieldsAndValues, false)); });
+});
+exports.deleteDoc = (function (reference) {
+    return trySignInWithCustomToken(function () { return (0, firestore_1.deleteDoc)(reference); });
+});
+function validCustomToken(db, id) {
+    var docRef = (0, firestore_1.doc)(db, 'store', id);
+    return (0, firestore_1.getDoc)(docRef);
+}
+exports.validCustomToken = validCustomToken;
+function getUserDoc(db, email) {
+    var paths = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        paths[_i - 2] = arguments[_i];
+    }
+    return firestore_1.doc.apply(void 0, __spreadArray([db, 'store', email], paths, false));
+}
+exports.getUserDoc = getUserDoc;
+function getUserCollection(db, email) {
+    var paths = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        paths[_i - 2] = arguments[_i];
+    }
+    return firestore_1.collection.apply(void 0, __spreadArray([db, 'store', email], paths, false));
+}
+exports.getUserCollection = getUserCollection;
+function findOne(q) {
+    var _a;
+    return __awaiter(this, void 0, void 0, function () {
+        var querySnap;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0: return [4 /*yield*/, (0, exports.getDocs)(q)];
+                case 1:
+                    querySnap = _b.sent();
+                    return [2 /*return*/, (_a = querySnap.docs[0]) !== null && _a !== void 0 ? _a : null];
+            }
+        });
+    });
+}
+exports.findOne = findOne;
+function findMany(q) {
+    return __awaiter(this, void 0, void 0, function () {
+        var querySnap, result;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, (0, exports.getDocs)(q)];
+                case 1:
+                    querySnap = _a.sent();
+                    result = [];
+                    querySnap.forEach(function (doc) { return result.push(doc); });
+                    return [2 /*return*/, result];
+            }
+        });
+    });
+}
+exports.findMany = findMany;


### PR DESCRIPTION
I've discovered that the updateUser method of the adapter in Firestore overwrites the record if it already exists. This results in user information being lost upon update. For example, when logging in with the email provider.

Right now the bug is this:

1. User collection has the following record:
```
{
      id: '12345'
      emailVerified: <some timestamp>
      email: 'jsmith@example.com'
      image: <some image>
      name: 'John Smith'
}
```
2. User logs in with email, and as a consequence, `next-auth` calls the `updateUser` method of the adapter with the data:
```
{
      id: '12345'
      emailVerified: <some NEWER timestamp>
}
```
3. Record gets overwritten completely and is now:
```
{
      id: '12345'
      emailVerified: <some NEWER timestamp>
}
```

This pull request sets the `merge` flag on the firebase `set` command to `true` so that the record isn't overwritten.

However, this isn't enough, because `next-auth` expects to receive the updated record _including_ the original fields, which means we need to somehow get the original fields (otherwise, the session won't include the user's profile).

Unfortunately, the firebase javascript SDK (unlike the REST API) does _not_ return the updated record in response to `set` or `create` calls (see [here](https://stackoverflow.com/questions/52678252/firestore-get-document-back-after-adding-it-updating-it-without-additional-ne)). As a consequence, we must make an additional call to retrieve the updated record, and then return that to `next-auth`.

This pull request takes care of both of these changes. Please keep in mind that I have not updated any other methods or anything outside of the firestore database (if the firebase file needs to be updated as well, this should be done, too. However, I am unfamiliar with it).